### PR TITLE
simplify translation files

### DIFF
--- a/SolastaModTemplate/Main.cs
+++ b/SolastaModTemplate/Main.cs
@@ -21,30 +21,30 @@ namespace SolastaModTemplate
 
         internal static void LoadTranslations()
         {
-            var languageSourceData = LocalizationManager.Sources[0];
-            var translationsPath = Path.Combine(UnityModManager.modsPath, @"SolastaModTemplate\Translations.json");
-            if (File.Exists(translationsPath))
+            DirectoryInfo directoryInfo = new DirectoryInfo($@"{UnityModManager.modsPath}/SolastaModTemplate");
+            FileInfo[] files = directoryInfo.GetFiles($"Translations-??.txt");
+
+            foreach (var file in files)
             {
-                var translations = JObject.Parse(File.ReadAllText(translationsPath));
-                foreach (var translationKey in translations)
-                {
-                    foreach (var translationLanguage in (JObject)translationKey.Value)
+                var filename = $@"{UnityModManager.modsPath}/SolastaModTemplate/{file.Name}";
+                var code = file.Name.Substring(13, 2);
+                var languageSourceData = LocalizationManager.Sources[0];
+                var languageIndex = languageSourceData.GetLanguageIndexFromCode(code);
+
+                if (languageIndex < 0)
+                    Main.Error($"language {code} not currently loaded.");
+                else
+                    using (var sr = new StreamReader(filename))
                     {
-                        try
+                        String line;
+                        while ((line = sr.ReadLine()) != null)
                         {
-                            var languageIndex = languageSourceData.GetLanguageIndex(translationLanguage.Key);
-                            languageSourceData.AddTerm(translationKey.Key).Languages[languageIndex] = translationLanguage.Value.ToString();
-                        }
-                        catch (IndexOutOfRangeException)
-                        {
-                            Error($"language {translationLanguage.Key} not installed");
-                        }
-                        catch (KeyNotFoundException)
-                        {
-                            Error($"term {translationKey.Key} not found");
+                            var splitted = line.Split(new[] { '\t', ' ' }, 2);
+                            var term = splitted[0];
+                            var text = splitted[1];
+                            languageSourceData.AddTerm(term).Languages[languageIndex] = text;
                         }
                     }
-                }
             }
         }
 

--- a/SolastaModTemplate/SolastaModTemplate.csproj
+++ b/SolastaModTemplate/SolastaModTemplate.csproj
@@ -409,7 +409,7 @@
 		<None Update="Repository.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
-		<None Update="Translations.json">
+		<None Update="Translations-en.txt">
 		  <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
 	</ItemGroup>

--- a/SolastaModTemplate/Translations-en.txt
+++ b/SolastaModTemplate/Translations-en.txt
@@ -1,0 +1,2 @@
+SolastaModTemplate/&SomeTerm    I'm some translation term
+SolastaModTemplate/&OtherTerm	I'm another translation term

--- a/SolastaModTemplate/Translations.json
+++ b/SolastaModTemplate/Translations.json
@@ -1,9 +1,0 @@
-{
-  "SolastaModTemplate/&SomeTerm": {
-    "English": "Mickey-Mouse was here"
-  },
-  "SolastaModTemplate/&OtherTerm": {
-    "English": "The book is on the table",
-    "Portuguese": "O livro esta sobre a mesa"
-  }
-}


### PR DESCRIPTION
### Change how translations work

Replaced one single Translations JSON file with simpler text ones. Translation files are named Translations-#CODE#.txt (i.e: Translations-en.txt). Translation files are tab separated with 2 columns. Term comes first and the text comes last.